### PR TITLE
Multiple code improvements - squid:S1118, squid:S1149, squid:S2583, squid:S2259

### DIFF
--- a/src/main/java/org/clitherproject/clither/server/ClitherServer.java
+++ b/src/main/java/org/clitherproject/clither/server/ClitherServer.java
@@ -117,23 +117,22 @@ public class ClitherServer implements Server {
     }
 
     public void saveConfig() {
-        PrintWriter writer = null;
         try {
-            writer = new PrintWriter("server.properties", "UTF-8");
+            PrintWriter writer = new PrintWriter("server.properties", "UTF-8");
+            writer.println("name=Unknown Server");
+            writer.println("ip=localhost");
+            writer.println("port=443");
+            writer.println("maxPlayers=20");
+            writer.println("maxMass=85500");
+            writer.println("foodSize=1");
+            writer.println("foodStartAmount=100");
+            writer.println("startMass=35");
+            writer.println("borderSize=6000");
+            writer.close();
         } catch (Exception ex) {
             log.severe("An internal error has occured whilist generating server.properties.");
             shutdown();
         }
-        writer.println("name=Unknown Server");
-        writer.println("ip=localhost");
-        writer.println("port=443");
-        writer.println("maxPlayers=20");
-        writer.println("maxMass=85500");
-        writer.println("foodSize=1");
-        writer.println("foodStartAmount=100");
-        writer.println("startMass=35");
-        writer.println("borderSize=6000");
-        writer.close();
         loadConfig();
     }
 

--- a/src/main/java/org/clitherproject/clither/server/PlayerList.java
+++ b/src/main/java/org/clitherproject/clither/server/PlayerList.java
@@ -33,9 +33,9 @@ public class PlayerList {
 
     @SuppressWarnings("unused")
     public void removePlayer(PlayerImpl player) {
-        log.info(player.getAddress().toString().split(":")[0]+" ("+player.getClientID()+") has disconnected from the server!");
-        players.remove(player);
         if (player != null) {
+            log.info(player.getAddress().toString().split(":")[0]+" ("+player.getClientID()+") has disconnected from the server!");
+            players.remove(player);
             for (Snake snake : player.getSnakes()) {
                 server.getWorld().removeEntity(null);
             }

--- a/src/main/java/org/clitherproject/clither/server/command/Commands.java
+++ b/src/main/java/org/clitherproject/clither/server/command/Commands.java
@@ -9,6 +9,8 @@ import org.clitherproject.clither.server.world.PlayerImpl;
 @SuppressWarnings("unused")
 public class Commands {
 
+    private Commands() {}
+
 	public static void onCommand(String s) {
         switch (s.toLowerCase().split(" ")[0]) {
         case "help":

--- a/src/main/java/org/clitherproject/clither/server/config/Configuration.java
+++ b/src/main/java/org/clitherproject/clither/server/config/Configuration.java
@@ -7,6 +7,8 @@ import java.util.logging.Logger;
 public class Configuration {
 
     static Logger log = Logger.getGlobal();
+
+    private Configuration() {}
     
     public static ClitherConfig load(String file) {
         try(FileReader reader = new FileReader(file)) {

--- a/src/main/java/org/clitherproject/clither/server/gui/ServerGUI.java
+++ b/src/main/java/org/clitherproject/clither/server/gui/ServerGUI.java
@@ -97,7 +97,7 @@ public class ServerGUI {
     private static class TextAreaOutputStream extends OutputStream {
 
         private final JTextArea textArea;
-        private final StringBuffer buffer = new StringBuffer();
+        private final StringBuilder buffer = new StringBuilder();
 
         public TextAreaOutputStream(JTextArea textArea) {
             this.textArea = textArea;

--- a/src/main/java/org/clitherproject/clither/server/util/MathHelper.java
+++ b/src/main/java/org/clitherproject/clither/server/util/MathHelper.java
@@ -18,6 +18,8 @@ package org.clitherproject.clither.server.util;
 
 public class MathHelper {
 
+    private MathHelper() {}
+
     /**
      * A fast absolute value function.
      * <p>


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
squid:S2259 - Null pointers should not be dereferenced.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:S2583
https://dev.eclipse.org/sonar/rules/show/squid:S2259
Please let me know if you have any questions.
George Kankava