### PR TITLE
Multiple code improvements - squid:S1854, squid:S1148, squid:S1481, squid:S1858, squid:S2184

### DIFF
--- a/src/main/java/org/clitherproject/clither/server/ClitherServer.java
+++ b/src/main/java/org/clitherproject/clither/server/ClitherServer.java
@@ -192,8 +192,7 @@ public class ClitherServer implements Server {
         try {
             networkManager.start();
         } catch (IOException | InterruptedException ex) {
-            log.info("Failed to start server! " + ex.getMessage());
-            ex.printStackTrace();
+            log.log(Level.SEVERE, "Failed to start server! " + ex.getMessage(), ex);
             if (ServerGUI.isSpawned()) {
                 System.exit(1);
             } else {
@@ -229,7 +228,7 @@ public class ClitherServer implements Server {
         try {
             Thread.sleep(1500);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            log.log(Level.SEVERE, e.getMessage(), e);
         }
         System.exit(-1);
     }

--- a/src/main/java/org/clitherproject/clither/server/config/Configuration.java
+++ b/src/main/java/org/clitherproject/clither/server/config/Configuration.java
@@ -28,7 +28,7 @@ public class Configuration {
             return conf;
         } catch (Exception ex) {
             log.info("An internal error has occured whilist reading configuration file!");
-            log.info(ex.getMessage().toString());
+            log.info(ex.getMessage());
             return new ClitherConfig();
         }
     }

--- a/src/main/java/org/clitherproject/clither/server/entity/EntityImpl.java
+++ b/src/main/java/org/clitherproject/clither/server/entity/EntityImpl.java
@@ -77,7 +77,7 @@ public abstract class EntityImpl implements Entity, Tickable {
 
     @Override
     public int getPhysicalSize() {
-        return (int) Math.ceil(Math.sqrt(100 * mass));
+        return (int) Math.ceil(Math.sqrt(100D * mass));
     }
 
     @Override

--- a/src/main/java/org/clitherproject/clither/server/entity/impl/SnakeImpl.java
+++ b/src/main/java/org/clitherproject/clither/server/entity/impl/SnakeImpl.java
@@ -62,7 +62,6 @@ public class SnakeImpl extends EntityImpl implements Snake {
         }
 
         PlayerImpl player = (PlayerImpl) owner;
-        int r = getPhysicalSize();
 
         PlayerConnection.MousePosition mouse = player.getConnection().getCellMousePosition(getID());
         if (mouse == null || !player.getConnection().isIndividualMovementEnabled()) {
@@ -129,9 +128,6 @@ public class SnakeImpl extends EntityImpl implements Snake {
             if (other instanceof FoodImpl) {
                 edibles.add(other);
                 continue;
-            } else if (other instanceof SnakeImpl) {
-                SnakeImpl otherCell = (SnakeImpl) other;
-
             }
 
             // Is the other cell big enough to eat?

--- a/src/main/java/org/clitherproject/clither/server/gui/ServerCLI.java
+++ b/src/main/java/org/clitherproject/clither/server/gui/ServerCLI.java
@@ -18,11 +18,13 @@ package org.clitherproject.clither.server.gui;
 
 import org.clitherproject.clither.server.ClitherServer;
 import java.io.IOException;
-import jline.TerminalFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jline.console.ConsoleReader;
 
 public class ServerCLI implements Runnable {
 
+    public static final Logger log = Logger.getGlobal();
     private final ClitherServer server;
 
     public ServerCLI(ClitherServer server) {
@@ -39,12 +41,12 @@ public class ServerCLI implements Runnable {
                 server.handleCommand(line);
             }
         } catch (IOException ex) {
-            ex.printStackTrace();
+            log.log(Level.SEVERE, ex.getMessage(), ex);
         } finally {
             try {
-                TerminalFactory.get().restore();
             } catch (Exception ex) {
                 ex.printStackTrace();
+                log.log(Level.SEVERE, ex.getMessage(), ex);
             }
         }
     }

--- a/src/main/java/org/clitherproject/clither/server/tick/TickWorker.java
+++ b/src/main/java/org/clitherproject/clither/server/tick/TickWorker.java
@@ -2,11 +2,14 @@ package org.clitherproject.clither.server.tick;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Created by Porama2 on 15/4/2016.
  */
 public class TickWorker extends Thread {
+    public static final Logger log = Logger.getGlobal();
     List<Tickable> works = new ArrayList<>();
 
     public void add(Tickable work) {
@@ -23,7 +26,7 @@ public class TickWorker extends Thread {
             try {
                 tickable.tick();
             } catch (Exception e) {
-                e.printStackTrace();
+                log.log(Level.SEVERE, e.getMessage(), e);
             }
         }
         works.clear();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - Dead stores should be removed.
squid:S1148 - Throwable.printStackTrace(...) should not be called.
squid:S1481 - Unused local variables should be removed.
squid:S1858 - "toString()" should never be called on a String object.
squid:S2184 - Math operands should be cast before assignment.
squid:UselessImportCheck - Useless imports should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1148
https://dev.eclipse.org/sonar/rules/show/squid:S1481
https://dev.eclipse.org/sonar/rules/show/squid:S1858
https://dev.eclipse.org/sonar/rules/show/squid:S2184
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck
Please let me know if you have any questions.
George Kankava