### PR TITLE
Multiple code improvements - squid:S2160, squid:SwitchLastCaseIsDefaultCheck, squid:S1170, squid:S2786, squid:UselessParenthesesCheck

### DIFF
--- a/src/main/java/org/clitherproject/clither/server/ClitherServer.java
+++ b/src/main/java/org/clitherproject/clither/server/ClitherServer.java
@@ -31,7 +31,7 @@ public class ClitherServer implements Server {
     public static final Logger log = Logger.getGlobal();
     private static ClitherServer instance;
     private final PlayerList playerList = new PlayerList(this);
-    private final String configurationFile = "server.properties";
+    private static final String configurationFile = "server.properties";
     private final boolean debugMode = Boolean.getBoolean("debug");
     private final Set<TickWorker> tickWorkers = new HashSet<TickWorker>();
     private final Messenger messenger = new Messenger();

--- a/src/main/java/org/clitherproject/clither/server/command/Commands.java
+++ b/src/main/java/org/clitherproject/clither/server/command/Commands.java
@@ -32,7 +32,8 @@ public class Commands {
         case "stop":
             ClitherServer.getInstance().shutdown();
             break;
-		
+        default:
+            break;
         }
 	}
 }

--- a/src/main/java/org/clitherproject/clither/server/entity/impl/SnakeImpl.java
+++ b/src/main/java/org/clitherproject/clither/server/entity/impl/SnakeImpl.java
@@ -162,4 +162,25 @@ public class SnakeImpl extends EntityImpl implements Snake {
     private boolean simpleCollide(Snake other, double collisionDist) {
         return MathHelper.fastAbs(getX() - other.getPosition().getX()) < (2 * collisionDist) && MathHelper.fastAbs(getY() - other.getPosition().getY()) < (2 * collisionDist);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SnakeImpl snake = (SnakeImpl) o;
+
+        if (owner != null ? !owner.equals(snake.owner) : snake.owner != null) return false;
+        return name != null ? name.equals(snake.name) : snake.name == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (owner != null ? owner.hashCode() : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/main/java/org/clitherproject/clither/server/net/PlayerConnection.java
+++ b/src/main/java/org/clitherproject/clither/server/net/PlayerConnection.java
@@ -99,7 +99,7 @@ public class PlayerConnection {
         return true;
     }
 
-    private static enum ConnectionState {
+    private enum ConnectionState {
 
         AUTHENTICATE, RESET, CONNECTED;
     }

--- a/src/main/java/org/clitherproject/clither/server/world/WorldImpl.java
+++ b/src/main/java/org/clitherproject/clither/server/world/WorldImpl.java
@@ -151,8 +151,8 @@ public class WorldImpl implements World {
     }
 
     public Position getRandomPosition() {
-        return new Position((random.nextDouble() * (Math.abs(border.left) + Math.abs(border.right))),
-                (random.nextDouble() * (Math.abs(border.top) + Math.abs(border.bottom))));
+        return new Position(random.nextDouble() * (Math.abs(border.left) + Math.abs(border.right)),
+                random.nextDouble() * (Math.abs(border.top) + Math.abs(border.bottom)));
     }
 
     private void spawnFood() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2160 - Subclasses that add fields should override "equals".
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S1170 - Public constants should be declared "static final" rather than merely "final".
squid:S2786 - Nested "enum"s should not be declared static.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2160
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1170
https://dev.eclipse.org/sonar/rules/show/squid:S2786
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava