### PR TITLE
Multiple code improvements - squid:UnusedPrivateMethod, squid:S1700, squid:S00116, squid:S1068

### DIFF
--- a/src/main/java/org/clitherproject/clither/server/net/Handshaker.java
+++ b/src/main/java/org/clitherproject/clither/server/net/Handshaker.java
@@ -8,7 +8,7 @@ import io.netty.handler.codec.http.websocketx.*;
 
 @SuppressWarnings("rawtypes")
 public class Handshaker extends SimpleChannelInboundHandler {
-    private WebSocketServerHandshaker handshaker;
+    private WebSocketServerHandshaker serverHandshaker;
 
     @Override
     protected void channelRead0(ChannelHandlerContext handlerContext, Object request) throws Exception {
@@ -16,20 +16,20 @@ public class Handshaker extends SimpleChannelInboundHandler {
         if (request instanceof FullHttpRequest) {
             FullHttpRequest fullRequest = (FullHttpRequest) request;
             WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory("ws://" + fullRequest.headers().get(HttpHeaders.HOST) + "/", null, true);
-            handshaker = wsFactory.newHandshaker(fullRequest);
+            serverHandshaker = wsFactory.newHandshaker(fullRequest);
 
-            if (handshaker == null) {
+            if (serverHandshaker == null) {
                 WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(handlerContext.channel());
             } else {
-                handshaker.handshake(handlerContext.channel(), fullRequest);
+                serverHandshaker.handshake(handlerContext.channel(), fullRequest);
             }
         } else if (request instanceof WebSocketFrame) {
 
             WebSocketFrame frame = (WebSocketFrame) request;
 
             if (request instanceof CloseWebSocketFrame) {
-                if (handshaker != null) {
-                    handshaker.close(handlerContext.channel(), ((CloseWebSocketFrame) request).retain());
+                if (serverHandshaker != null) {
+                    serverHandshaker.close(handlerContext.channel(), ((CloseWebSocketFrame) request).retain());
                 }
             } else if (request instanceof PingWebSocketFrame) {
                 handlerContext.channel().write(new PongWebSocketFrame(frame.content().retain()));

--- a/src/main/java/org/clitherproject/clither/server/net/PlayerConnection.java
+++ b/src/main/java/org/clitherproject/clither/server/net/PlayerConnection.java
@@ -20,17 +20,13 @@ import org.clitherproject.clither.server.world.PlayerImpl;
 public class PlayerConnection {
 
     static Logger log = Logger.getGlobal();
-    private final PlayerImpl player;
     private final Channel channel;
     private final Map<Integer, MousePosition> cellMousePositions = new HashMap<>();
     private boolean individualMovementEnabled = false;
     private MousePosition globalMousePosition;
     private ConnectionState state = ConnectionState.AUTHENTICATE;
-    private int protocolVersion;
-	private String authToken;
 
     public PlayerConnection(PlayerImpl player, Channel channel) {
-        this.player = player;
         this.channel = channel;
     }
 

--- a/src/main/java/org/clitherproject/clither/server/net/packet/inbound/PacketInNewSnake.java
+++ b/src/main/java/org/clitherproject/clither/server/net/packet/inbound/PacketInNewSnake.java
@@ -4,8 +4,8 @@ import io.netty.buffer.ByteBuf;
 import org.clitherproject.clither.server.net.packet.Packet;
 
 public class PacketInNewSnake extends Packet {
-    int U1 = 0; //UNKNOWN
-    int U2 = 0; //UNKNOWN
+    int u1 = 0; //UNKNOWN
+    int u2 = 0; //UNKNOWN
     int packetType = -1;
     
 	@Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:UnusedPrivateMethod - Unused private method should be removed.
squid:S1700 - A field should not duplicate the name of its containing class.
squid:S00116 - Field names should comply with a naming convention.
squid:S1068 - Unused private fields should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UnusedPrivateMethod
https://dev.eclipse.org/sonar/rules/show/squid:S1700
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:S1068
Please let me know if you have any questions.
George Kankava